### PR TITLE
imv: add custom command completer with case-insensitive matching

### DIFF
--- a/src/cli/command_completer.py
+++ b/src/cli/command_completer.py
@@ -1,0 +1,47 @@
+from typing import Iterable, List
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+from prompt_toolkit.completion import CompleteEvent
+
+
+class CommandCompleter(Completer):
+    """
+    A custom completer for CLI commands.
+
+    It only provides completions when the cursor is positioned in the first word
+    (i.e., the command name), and ignores further arguments.
+
+    Completions are case-insensitive.
+    """
+
+    def __init__(self, commands: List[str]) -> None:
+        """
+        Initialize the completer with a list of available commands.
+
+        :param commands: A list of command strings to complete from.
+        """
+        self.commands = commands
+
+    def get_completions(
+        self, document: Document, complete_event: CompleteEvent
+    ) -> Iterable[Completion]:
+        """
+        Yield command completions for the current input.
+
+        :param document: The Document instance representing the current input.
+        :param complete_event: The completion trigger event (unused).
+        :yield: Completion suggestions for matching commands.
+        """
+        text = document.text_before_cursor
+        words = text.strip().split()
+
+        # Only suggest completions for the first word
+        cursor_pos = document.cursor_position
+        first_space = text.find(" ")
+        if first_space != -1 and cursor_pos > first_space:
+            return  # Cursor is past the first word → don't show completions
+
+        fragment = words[0].lower() if words else ""
+        for command in self.commands:
+            if command.lower().startswith(fragment):
+                yield Completion(command, start_position=-len(fragment))

--- a/src/cli/context_manager.py
+++ b/src/cli/context_manager.py
@@ -1,4 +1,4 @@
-from prompt_toolkit.completion import WordCompleter
+from cli.command_completer import CommandCompleter
 from typing import Callable, Dict, Optional, List
 from cli.enums import Context
 from cli.messages import Messages
@@ -10,7 +10,7 @@ class ContextManager:
     def __init__(self):
         self.current_context = Context.MAIN
         self.commands_by_context: Dict[Context, List[str]] = {}
-        self.command_completer: Optional[WordCompleter] = None
+        self.command_completer: Optional[CommandCompleter] = None
 
     def register_commands(self, context: Context, commands: List[str]) -> None:
         """
@@ -45,4 +45,4 @@ class ContextManager:
     def _update_completer(self) -> None:
         """Update command completer for current context."""
         commands = self.commands_by_context.get(self.current_context, [])
-        self.command_completer = WordCompleter(commands, ignore_case=True)
+        self.command_completer = CommandCompleter(commands)


### PR DESCRIPTION
- Implemented CommandCompleter to replace WordCompleter
- Shows suggestions only for the first word (command) before arguments
- Added type hints and docstring for clarity and maintainability