### PR TITLE
imv: support Cyrillic (QWERTY-based) input for command suggestions and yes/no prompts

### DIFF
--- a/src/cli/command_completer.py
+++ b/src/cli/command_completer.py
@@ -2,6 +2,7 @@ from typing import Iterable, List
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.document import Document
 from prompt_toolkit.completion import CompleteEvent
+from cli.keyboard_layout import KEYBOARD_LAYOUT
 
 
 class CommandCompleter(Completer):
@@ -42,6 +43,21 @@ class CommandCompleter(Completer):
             return  # Cursor is past the first word → don't show completions
 
         fragment = words[0].lower() if words else ""
+        fragment_lower = fragment.lower()
+        translit_fragment = self._translate_layout(fragment_lower)
+        current_word = document.get_word_before_cursor()
+
         for command in self.commands:
-            if command.lower().startswith(fragment):
-                yield Completion(command, start_position=-len(fragment))
+            cmd_lower = command.lower()
+            if cmd_lower.startswith(fragment_lower) or cmd_lower.startswith(
+                translit_fragment
+            ):
+                # Show completion starting from the beginning of the current word being typed
+                yield Completion(
+                    command,
+                    start_position=-len(current_word),
+                )
+
+    def _translate_layout(self, input_str: str) -> str:
+        """Translates a string typed in Cyrillic as if on a QWERTY keyboard to Latin."""
+        return input_str.translate(KEYBOARD_LAYOUT)

--- a/src/cli/confirm.py
+++ b/src/cli/confirm.py
@@ -21,6 +21,8 @@ def confirm(question: str) -> bool:
 
     @bindings.add("y")
     @bindings.add("Y")
+    @bindings.add("н")  # Cyrillic equivalent of 'y' key in QWERTY
+    @bindings.add("Н")
     def _(event):
         nonlocal result
         result = True
@@ -28,6 +30,8 @@ def confirm(question: str) -> bool:
 
     @bindings.add("n")
     @bindings.add("N")
+    @bindings.add("т")  # Cyrillic equivalent of 'n' key in QWERTY
+    @bindings.add("Т")
     def _(event):
 
         nonlocal result

--- a/src/cli/context_manager.py
+++ b/src/cli/context_manager.py
@@ -2,6 +2,7 @@ from cli.command_completer import CommandCompleter
 from typing import Callable, Dict, Optional, List
 from cli.enums import Context
 from cli.messages import Messages
+from cli.keyboard_layout import KEYBOARD_LAYOUT
 
 
 class ContextManager:
@@ -10,6 +11,7 @@ class ContextManager:
     def __init__(self):
         self.current_context = Context.MAIN
         self.commands_by_context: Dict[Context, List[str]] = {}
+        self.normalized_commands_by_context: Dict[Context, List[str]] = {}
         self.command_completer: Optional[CommandCompleter] = None
 
     def register_commands(self, context: Context, commands: List[str]) -> None:
@@ -20,11 +22,14 @@ class ContextManager:
         :param commands: List of available commands
         """
         self.commands_by_context[context] = commands
+        self.normalized_commands_by_context[context] = [
+            cmd.lower().translate(KEYBOARD_LAYOUT) for cmd in commands
+        ]
         self._update_completer()
 
     @property
     def available_commands(self) -> List[str]:
-        return self.commands_by_context.get(self.current_context, [])
+        return self.normalized_commands_by_context.get(self.current_context, [])
 
     def switch_context(
         self, context: Context, on_switch: Optional[Callable] = None
@@ -44,5 +49,5 @@ class ContextManager:
 
     def _update_completer(self) -> None:
         """Update command completer for current context."""
-        commands = self.commands_by_context.get(self.current_context, [])
+        commands = self.normalized_commands_by_context.get(self.current_context, [])
         self.command_completer = CommandCompleter(commands)

--- a/src/cli/keyboard_layout.py
+++ b/src/cli/keyboard_layout.py
@@ -1,0 +1,4 @@
+# Translates Cyrillic input typed in QWERTY layout to the corresponding Latin characters.
+KEYBOARD_LAYOUT = str.maketrans(
+    "йцукенгшщзхъфывапролджэячсмитьбюіїєґё", "qwertyuiop[]asdfghjkl;'zxcvbnm,.iie`~"
+)


### PR DESCRIPTION

This commit introduces support for users typing in Cyrillic layout mapped to Latin QWERTY keys. The following enhancements are included:

- Transliteration is applied when suggesting commands, so typing Cyrillic equivalents (e.g., 'сщтефсеыы' → 'contactss') still triggers fuzzy suggestions.
- The confirmation prompt now accepts Cyrillic equivalents: 'н'/'Н' for yes and 'т'/'Т' for no.
- Available commands are pre-normalized in the context manager to ensure consistent fuzzy matching.
- The completer logic checks both raw and transliterated fragments for interactive suggestions.

This improves usability for users who accidentally type in Cyrillic layout.